### PR TITLE
Distribute client and engine

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,0 +1,8 @@
+{
+    "versions": [
+        {
+            "release_version": "2020.0.0.0.0",
+            "changes": "first working version!"
+        }
+    ]
+}


### PR DESCRIPTION
Release a new version by making a release in the `battlecode20-dist` repo.