### PR TITLE
Parametrize backend url based on prod/dev environments

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_URL=http://localhost:8000

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_URL=https://2020.battlecode.org

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2,7 +2,9 @@ import $ from 'jquery';
 import * as Cookies from 'js-cookie';
 
 //const URL = 'https://2020.battlecode.org';
-const URL = 'http://localhost:8000'; // DEVELOPMENT
+//const URL = 'http://localhost:8000'; // DEVELOPMENT
+// do not change URL here!! rather, for development, change it in ../.env.development
+const URL = process.env.REACT_APP_BACKEND_URL;
 const DONOTREQUIRELOGIN = false; // set to true for DEVELOPMENT
 const LEAGUE = 0;
 const PAGE_LIMIT = 10;


### PR DESCRIPTION
Now, we don't need to change the source code before deploying, which is better. The url is taken from `.env.production` for deployment and `.env.development` for development.