### PR TITLE
BugFix: Dropped units are always destroyed

### DIFF
--- a/engine/src/main/battlecode/world/RobotControllerImpl.java
+++ b/engine/src/main/battlecode/world/RobotControllerImpl.java
@@ -812,8 +812,8 @@ public final strictfp class RobotControllerImpl implements RobotController {
 
         gameWorld.getMatchMaker().addAction(getID(), Action.DROP_UNIT, id);
 
-        // unit is destroyed if dropped in Ocean, onto a building, or onto another unit
-        if (isLocationOccupied(targetLocation) || this.gameWorld.isFlooded(targetLocation))
+        // unit is destroyed if dropped in Ocean
+        if (this.gameWorld.isFlooded(targetLocation))
             this.gameWorld.destroyRobot(id);
     }
 


### PR DESCRIPTION
assertCanDropUnit will `throw new GameActionException(CANT_MOVE_THERE,...`  if a robot is already present. Consequently, dropUnit does not need to check for a robot. Currently, this.gameWorld.addRobot(targetLocation, droppedRobot) means the unit at targetLocation check will always be true. 

See conversation started by tscmoo in discord #engine-bugs 3:53 EST.