### PR TITLE
Allow compilation update to override past errors

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -525,7 +525,7 @@ class SubmissionViewSet(viewsets.GenericViewSet,
         is_admin = User.objects.all().get(username=request.user).is_superuser
         if is_admin:
             submission = self.get_queryset().get(pk=pk)
-            if submission.compilation_status != 0:
+            if submission.compilation_status != 0 and submission.compilation_status != 3:
                 return Response({'message': 'Response already received for this submission'}, status.HTTP_400_BAD_REQUEST)
             comp_status = int(request.data.get('compilation_status'))
 


### PR DESCRIPTION
Just in case the compile server sends a server error, allow it to try to rectify that later on