### PR TITLE
Fix for drone dropping unit location not updating

### DIFF
--- a/engine/src/main/battlecode/world/RobotControllerImpl.java
+++ b/engine/src/main/battlecode/world/RobotControllerImpl.java
@@ -807,6 +807,7 @@ public final strictfp class RobotControllerImpl implements RobotController {
         MapLocation targetLocation = dir == null ? getLocation() : adjacentLocation(dir);
 
         droppedRobot.unblockUnit();
+        movePickedUpUnit(targetLocation);
         this.robot.dropUnit();
         this.gameWorld.addRobot(targetLocation, droppedRobot);
 


### PR DESCRIPTION
When dropping a robot from a drone, the InternalRobot location is not updated to the location dropped. As a result, when attempting to destroy the unit if the dropped tile is flooded, the wrong location is destroyed. The patch updates the location of the unit about to be dropped right before the drone drops the unit.