### PR TITLE
Fix onTheMap

### DIFF
--- a/engine/src/main/battlecode/common/RobotController.java
+++ b/engine/src/main/battlecode/common/RobotController.java
@@ -150,16 +150,16 @@ public strictfp interface RobotController {
     // ***********************************
 
     /**
-     * Senses whether a MapLocation is on the map. Will throw an exception if
-     * the location is not within the sensor range.
+     * Senses whether a MapLocation is on the map. // Will throw an exception if
+     * the location is not currently within sensor range.
      *
      * @param loc the location to check
      * @return true if the location is on the map; false otherwise.
-     * @throws GameActionException if the location is not within sensor range.
+     * // @throws GameActionException if the location is not within sensor range.
      *
      * @battlecode.doc.costlymethod
      */
-    boolean onTheMap(MapLocation loc) throws GameActionException;
+    boolean onTheMap(MapLocation loc);
 
     /**
      * Senses whether the given location is within the robot's sensor range, and if it is on the map.

--- a/engine/src/main/battlecode/world/RobotControllerImpl.java
+++ b/engine/src/main/battlecode/world/RobotControllerImpl.java
@@ -159,9 +159,8 @@ public final strictfp class RobotControllerImpl implements RobotController {
     // ***********************************
 
     @Override
-    public boolean onTheMap(MapLocation loc) throws GameActionException {
+    public boolean onTheMap(MapLocation loc) {
         assertNotNull(loc);
-        assertCanSenseLocation(loc);
         return gameWorld.getGameMap().onTheMap(loc);
     }
 

--- a/engine/src/test/battlecode/world/RobotControllerTest.java
+++ b/engine/src/test/battlecode/world/RobotControllerTest.java
@@ -136,6 +136,37 @@ public class RobotControllerTest {
 
     }
     
+    @Test
+    public void testOnTheMap() throws GameActionException {
+        final int firstHq = 0;
+        final int sidelength = (int) Math.ceil(Math.sqrt(RobotType.HQ.sensorRadiusSquared) + 3);
+        LiveMap map = new TestMapBuilder("test", new MapLocation(0,0), sidelength, sidelength, 1337, 100, 5)
+            .addRobot(firstHq, Team.A, RobotType.HQ, new MapLocation(0, 0))
+            .addRobot(1, Team.B, RobotType.HQ, new MapLocation(0, 1))
+            .setSoup()
+            .setWater()
+            .setPollution()
+            .setDirt()
+            .build();
+
+        TestGame game = new TestGame(map);
+
+        game.round((id, rc) -> {
+            if (id == firstHq) {
+                // on map and visible
+                assertTrue(rc.onTheMap(new MapLocation(0, 0)));
+                // off of map and visible
+                assertFalse(rc.onTheMap(new MapLocation(-1, 0)));
+                assertFalse(rc.onTheMap(new MapLocation(0, -1)));
+                // on map but too far away to see
+                assertTrue(rc.onTheMap(new MapLocation(sidelength-1, 0)));
+                assertTrue(rc.onTheMap(new MapLocation(0, sidelength-1)));
+            }
+        });
+
+        game.waitRounds(1);
+    }
+
     /**
      * Ensure that actions take place immediately.
      */


### PR DESCRIPTION
Hey, I noticed that the `onTheMap` function was throwing an exception due to being out of sensor range, even when it was in sensor range. It turns out this is because `onTheMap` calls `assertCanSenseLocation`--but in turn `assertCanSenseLocation` calls `onTheMap`--so either it will return true, or it will always throw an exception, making it sort of useless.

Since the map height and width is now public info, the easy fix is to just make `onTheMap` not check the sensor range.