### PR TITLE
Much Better MapLocation.hash Method

### DIFF
--- a/engine/src/main/battlecode/common/MapLocation.java
+++ b/engine/src/main/battlecode/common/MapLocation.java
@@ -69,7 +69,7 @@ public final strictfp class MapLocation implements Serializable, Comparable<MapL
      */
     @Override
     public int hashCode() {
-        return this.x * 13 + this.y * 23;
+        return (this.y + 0x8000) & 0xffff | (this.x << 16);
     }
 
     public static MapLocation valueOf(String s) {


### PR DESCRIPTION
Granted, hash functions are never unique and do not have to be unique. Nevertheless, it is your job as as a programmer to create at least a decent hash function, which will reduce the collisions as much as possible over the set of the possible value your hash function is designed to encompass. In this case, MapLocation's x and y properties are no less than -1 and no greater than 64 in most cases. Your previous hash function is absolutely rotten and produces collisions all over the place within just this small set of numbers. The new hash function I propose guarantees a unique hash for each and every value of x and y in the range of -32768 to 32767. I strongly recommend that you accept this pull request so that MapLocation can have a decent hash function.