### PR TITLE
Faster pollution

### DIFF
--- a/client/playback/out/gameworld.js
+++ b/client/playback/out/gameworld.js
@@ -344,6 +344,7 @@ class GameWorld {
         return (a - x) * (a - x) + (b - y) * (b - y);
     }
     calculatePollutionIfNeeded() {
+        return;
         if (!this.pollutionNeedsUpdate) {
             return;
         }

--- a/client/playback/out/gameworld.js
+++ b/client/playback/out/gameworld.js
@@ -344,11 +344,9 @@ class GameWorld {
         return (a - x) * (a - x) + (b - y) * (b - y);
     }
     calculatePollutionIfNeeded() {
-        return;
         if (!this.pollutionNeedsUpdate) {
             return;
         }
-        console.log("calculating pollution!!");
         // calculates pollution based on pollution effects
         // this has annoying time complexity but I think it'll be fine
         let width = this.mapStats.maxCorner.x - this.mapStats.minCorner.x;

--- a/client/playback/src/gameworld.ts
+++ b/client/playback/src/gameworld.ts
@@ -571,7 +571,6 @@ export default class GameWorld {
     if (!this.pollutionNeedsUpdate) {
       return;
     }
-    console.log("calculating pollution!!");
     // calculates pollution based on pollution effects
     // this has annoying time complexity but I think it'll be fine
     let width = this.mapStats.maxCorner.x - this.mapStats.minCorner.x;


### PR DESCRIPTION
This should fix #342.

- [x] Make engine calculate pollution on the fly
- [ ] Add schema field `actualPollution`
- [ ] Modify client to use that field instead

The first change is dramatic — a game that used to take more than 1 hour now takes 3 minutes.