### PR TITLE
Reduce snapshot frequency in client to 256 

### DIFF
--- a/client/playback/out/match.js
+++ b/client/playback/out/match.js
@@ -28,7 +28,7 @@ class Match {
         this._current.loadFromMatchHeader(header);
         this._farthest = this._current;
         this.snapshots = [];
-        this.snapshotEvery = 64;
+        this.snapshotEvery = 256;
         this.snapshots.push(this._current.copy());
         this.deltas = new Array(1);
         this.logs = new Array(1);


### PR DESCRIPTION
As discussed with @Diuven we will reduce the snapshot frequency to every 256 turns.

This will improve the memory utilization and load time by a factor of 4.
It might screw with backwards playback. But that is janky rn anyways. (Actually it seems to be working better for me with it tho)